### PR TITLE
move test dependencies to right before running tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,10 +13,12 @@ RUN apt-get update && \
 # as not to mess with neural network libraries.
 # install the latest numpy because of this (https://stackoverflow.com/a/18204349).
 # also install grpcio here so local builds don't take as long
-RUN pip3 install -U torch torchvision mypy flake8 pylint pydocstyle numpy grpcio
+RUN pip3 install -U torch torchvision numpy grpcio
 
 COPY ./ /root/rlgear
 WORKDIR /root/rlgear
 RUN rm -rf $(find -name '*.pyc' -o -name '__pycache__')
 RUN pip3 install .
+
+RUN pip3 install -U mypy flake8 pylint pydocstyle
 RUN py.test-3 tests


### PR DESCRIPTION
This ensures local builds use the latest test dependencies
rather than a cached version from a previous build