### PR TITLE
speedup travis

### DIFF
--- a/tests/test_style.py
+++ b/tests/test_style.py
@@ -1,22 +1,38 @@
 import subprocess
 from pathlib import Path
+from typing import List, Any
+
+import pytest
 
 
-def test_style() -> None:
+@pytest.fixture
+def python_files() -> List[str]:
     python_paths = \
         (Path(__file__).resolve().parent.parent).rglob('*.py')
-    python_files = [str(p) for p in python_paths]
+    return [str(p) for p in python_paths]
+
+
+# pylint: disable=redefined-outer-name
+def test_flake8(python_files: Any) -> None:
     subprocess.check_call(['flake8'] + python_files)
+
+
+# pylint: disable=redefined-outer-name
+def test_pydocstyle(python_files: Any) -> None:
     subprocess.check_call(
         ['pydocstyle'] + python_files + ['--ignore=D1,D203,D213,D416'])
+
+
+# pylint: disable=redefined-outer-name
+def test_pylint(python_files: Any) -> None:
     rcfile = str(Path(__file__).resolve().parent / '.pylintrc')
     subprocess.check_call(
         ['pylint'] + python_files +
         [f'--rcfile={rcfile}', '--score=no', '--reports=no'])
+
+
+# pylint: disable=redefined-outer-name
+def test_mypy(python_files: Any) -> None:
     subprocess.check_call(
         ['mypy'] + python_files +
         ['--disallow-untyped-defs', '--ignore-missing-imports'])
-
-
-if __name__ == '__main__':
-    test_style()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -19,9 +19,5 @@ def test_import_class() -> None:
     assert all(box_obj.high == [1, 1])
 
 
-def main() -> None:
-    test_import_class()
-
-
 if __name__ == '__main__':
-    main()
+    test_import_class()


### PR DESCRIPTION
building in a virtual env allows for an upgraded pip to build grpc
faster (https://stackoverflow.com/a/63565433). It also enables a testing
environment that likely closer matches use cases with more up to date
packages than is what available thorugh apt.

test_style is also broken into separate tests for parallelization
enabled by pytest-xdist.